### PR TITLE
Bug 57409: univention-samba4-backup: don't touch backups every day

### DIFF
--- a/services/univention-samba4/sbin/univention-samba4-backup
+++ b/services/univention-samba4/sbin/univention-samba4-backup
@@ -97,5 +97,5 @@ install -o root -g root -m 700 -d "$WHERE"
 
 umask 0026 # samba-tool updates private/sam.ldb.d/metadata.tdb
 samba-tool domain backup offline --targetdir="$WHERE" || die "ERROR: samba-tool domain backup failed"
-chmod 600 "$WHERE"/samba-backup-*.bz2
+find "$WHERE" -name samba-backup-*.bz2 -a ! -perm 600 -print0 | xargs -0 chmod 600
 clean_old_backups 'samba/samba-backup-.*.bz2' "$DAYS"


### PR DESCRIPTION
## Please make sure you considered the following things

- [ X ] I read the [contribution guidelines](./CONTRIBUTING.md).
- [ X ] I read the [code of conduct](./CONTRIBUTING.md#code-of-conduct).
- [ X ] I created a bug report in the [Univention Bugzilla](https://forge.univention.org/bugzilla/index.cgi).
- [ X ] I will add a bugzilla comment about this pull request.

## Link to the issue in Bugzilla

https://forge.univention.org/bugzilla/show_bug.cgi?id=57409

## Description of the changes

The backups get their permissions changed every time the script is running. This changes the ctime of the file and causes inclusion to systembackups (e.g. bareos). This is especially annoying when many backupfiles are kept or the files are large.

This change uses find to only change the permission, where they are not as expected. 

Tested with UCS-5.0-8
